### PR TITLE
Add support for importing typescript files

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -32,7 +32,9 @@ class ScheduledFunctions {
       this.serverless.config.servicePath,
       configPath
     );
-    require('@babel/register');
+    require('@babel/register')({
+      extensions: ['.es6', '.es', '.jsx', '.js', '.mjs', '.ts', '.tsx'],
+    });
     require(functionsPaths);
   }
 


### PR DESCRIPTION
By default, `@babel/register` only resolves files with [extensions](https://babeljs.io/docs/en/babel-register/#usage) `.es6`, `.es`, `.jsx`, `.mjs`, and `.js`. To support additional file types, like Typescript, we need to extend this set of extensions with `.ts`, and `.tsx` as metioned in their [documentation](https://babeljs.io/docs/en/babel-register/#specifying-options).